### PR TITLE
Updating the US Senate's membership.

### DIFF
--- a/full-constitution
+++ b/full-constitution
@@ -542,3 +542,11 @@ Section 2. The Congress shall have power to enforce this article by appropriate 
 Amendment XXVII (1992)
 
 No law varying the compensation for the services of the Senators and Representatives shall take effect, until an election of Representatives shall have intervened.
+
+Amendment XXVIII (2020)
+
+This amendment supercedes Amendment XIII. The Senate of the United States shall be composed of Senators from each State, with one Senator for each 10 million individuals living in each state as of the most recent US Census, elected by the people thereof, for six years; and each Senator shall have one vote. States with fewew than 10 million people as of the most recent US Census shall have one Senator. The electors in each State shall have the qualifications requisite for electors of the most numerous branch of the State legislatures.
+
+When vacancies happen in the representation of any State in the Senate, the executive authority of such State shall issue writs of election to fill such vacancies: Provided, That the legislature of any State may empower the executive thereof to make temporary appointments until the people fill the vacancies by election as the legislature may direct.
+
+This amendment shall not be so construed as to affect the election or term of any Senator chosen before it becomes valid as part of the Constitution.

--- a/full-constitution
+++ b/full-constitution
@@ -545,7 +545,7 @@ No law varying the compensation for the services of the Senators and Representat
 
 Amendment XXVIII (2020)
 
-This amendment supercedes Amendment XIII. The Senate of the United States shall be composed of Senators from each State, with one Senator for each 10 million individuals living in each state as of the most recent US Census, elected by the people thereof, for six years; and each Senator shall have one vote. States with fewew than 10 million people as of the most recent US Census shall have one Senator. The electors in each State shall have the qualifications requisite for electors of the most numerous branch of the State legislatures.
+This amendment supercedes Amendment XIII. The Senate of the United States shall be composed of Senators from each State, with one Senator for each 4 million individuals living in each state as of the most recent US Census, elected by the people thereof, for six years; and each Senator shall have one vote. States with fewew than 4 million people as of the most recent US Census shall have one Senator. The electors in each State shall have the qualifications requisite for electors of the most numerous branch of the State legislatures.
 
 When vacancies happen in the representation of any State in the Senate, the executive authority of such State shall issue writs of election to fill such vacancies: Provided, That the legislature of any State may empower the executive thereof to make temporary appointments until the people fill the vacancies by election as the legislature may direct.
 


### PR DESCRIPTION
The growth in population and shifts in power have rendered the US Senate ineffective in the preservation of US Democracy and is failing to sustain the ideals upon which our country was founded. This change addresses that clear and present danger to the future of the United States of America.